### PR TITLE
Ensure provided headers are rendered in the response

### DIFF
--- a/lib/polyphony/http/server/http1_adapter.rb
+++ b/lib/polyphony/http/server/http1_adapter.rb
@@ -230,7 +230,7 @@ module Polyphony
           headers.each do |k, v|
             next if k =~ /^:/
 
-            format_header_lines(k, v)
+            data << format_header_lines(k, v)
           end
           data << "\r\n"
         end


### PR DESCRIPTION
### Description 📖 

Extracted out of #3, fixes a bug in the `HTTP1Adapter`, which was causing headers in the response to be ignored.

### Background 📜 

Noticed it by testing the sample Cuba app, and comparing the behavior of `bin/poly` vs `rackup`.

When visiting `/`, the expected behavior is that the browser follows the redirection to `/hello`.

Since the `Location` header was not being rendered in the response, when serving with `bin/poly` the browser just stayed there.